### PR TITLE
fixes to simulateTS

### DIFF
--- a/R/analyzeTS.R
+++ b/R/analyzeTS.R
@@ -341,7 +341,8 @@ simulateTS <- function(aTS, from = NULL, to = NULL) {
   dist <- attr(aTS, 'dist') ## get necesary info from attributes
   acsID <- attr(aTS, 'acsID')
   season <- attr(aTS, 'season')
-  date <- attr(aTS, 'date')
+  date <- (attr(aTS, 'date'))
+  names(date) <- "date"
 
   x <- aTS$data
 


### PR DESCRIPTION
attr() function in simulateTS() returns a vector when the original analyzed time series is created from a data frame.
data.table() is put before the attr() for the date variable.
Now there is no issue with vignette.