### PR TITLE
Replace `facet_grid(facets)`

### DIFF
--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -247,7 +247,7 @@ sim <- generateMTS(n = 500, STmodel = fit)
 dta <- melt(data = data.table(time = 1:nrow(sim), sim[,1:d]), id.vars = "time")
 
 ggplot(data = dta, mapping = aes(x = time, y = value)) + geom_line() +
-       facet_grid(facets = variable ~ ., scales = "free_y") + theme_light()
+       facet_grid(rows = variable ~ ., scales = "free_y") + theme_light()
 ```
 
 The function `generateMTSFast()` generates multiple time series with approximately separable STCS [(Serinaldi and Kilsby 2018)](https://doi.org/10.1029/2018WR023055), using an algorithm which is computationally less expensive than that in `generateMTS()`. This allows the simulation of a larger number of cross-correlated and serially dependent timeseries, at the cost of using separable STCSs and accepting some lack of accuracy in the exact reproduction of some terms of the required STCS [(Serinaldi and Kilsby 2018)](https://doi.org/10.1029/2018WR023055). 
@@ -273,7 +273,7 @@ sim <- generateMTSFast(n = 500,
 dta <- melt(data = data.table(time = 1:nrow(sim), sim[,1:d]), id.vars = "time")
 
 ggplot(data = dta, mapping = aes(x = time, y = value)) + geom_line() +
-       facet_grid(facets = variable ~ ., scales = "free_y") + theme_light()
+       facet_grid(rows = variable ~ ., scales = "free_y") + theme_light()
 ```
 
 ## Random Fields Simulation 


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The `facet_grid(facets)` argument has been deprecated since ggplot2 2.2.0 and is now defuct.
However, your vignette still uses this argument.
This PR updates those calls to use the current syntax.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun